### PR TITLE
Fix crash on data products with lower than 10 count

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -202,7 +202,13 @@ impl PointQuery {
     }
 }
 
-pub fn search(p: &Point, num: usize, hnsw: &HnswIndex) -> Result<Vec<PointQuery>, SearchError> {
+pub fn search(p: &Point, mut num: usize, hnsw: &HnswIndex) -> Result<Vec<PointQuery>, SearchError> {
+    // We need to set the number correctly
+    // to make sure we don't go out of bounds
+    let layer_len = hnsw.layer_len(0);
+    if layer_len < num {
+        num = layer_len;
+    }
     let mut output: Vec<_> = iter::repeat(Neighbor {
         index: !0,
         distance: !0,


### PR DESCRIPTION
In this change, we check whether the number of features is not lower than the count. If it is lower, we got out of bounds errors since it wanted to take a slice of the feature that it didn't have.

Therefore we now set the count equal to the amount of features if the count is higher.