### PR TITLE
ci: publish dev image as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
     needs: [clippy_and_format, build_and_test]
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
     permissions:
       contents: read
       packages: write
@@ -64,10 +64,21 @@ jobs:
           images: ${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .
           platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Build and push Docker image
+        if: github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
The dev image will be amd64 architecture only because it takes a really long time to build in QEMU otherwise (around 40 minutes). But it is nice to be able to have a dev image available that we can use to test without publicizing a new version.